### PR TITLE
fix npm install command

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -27,7 +27,7 @@ build-tree-sitter:
 	set -e; \
 	for pkg in $(TREE_SITTER_PACKAGES); do \
 	  echo "Install $$pkg"; \
-	  (cd $(PROJECT_ROOT) && npm install src/$$pkg); \
+	  (cd $(PROJECT_ROOT) && npm install $$pkg); \
 	done
 
 # Generate parsers for the semgrep-* packages.


### PR DESCRIPTION
PR fixes the npm install command.  With the master repo version, I'm getting the following `npm` error when running `make build` in the root directory (notice "src" in `git ls-remote ssh://git@github.com/src/tree-sitter-c-sharp.git`):
```
$ make build
make -C src build
make build-tree-sitter
set -e; \
	for pkg in tree-sitter-c-sharp tree-sitter-javascript tree-sitter-kotlin tree-sitter-ruby tree-sitter-typescript; do \
	  echo "Install $pkg"; \
	  (cd /Users/dmitris/dev/hack/github.com/returntocorp/ocaml-tree-sitter/lang/semgrep-grammars && npm install src/$pkg); \
	done
Install tree-sitter-c-sharp
npm ERR! code 128
npm ERR! command failed
npm ERR! command git ls-remote ssh://git@github.com/src/tree-sitter-c-sharp.git
npm ERR! ERROR: Repository not found.
npm ERR! fatal: Could not read from remote repository.
npm ERR!
npm ERR! Please make sure you have the correct access rights
npm ERR! and the repository exists.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/dmitris/.npm/_logs/2020-12-22T15_15_25_937Z-debug.log
make[2]: *** [build-tree-sitter] Error 128
make[1]: *** [build] Error 2
make: *** [build] Error 2
```