### PR TITLE
Add support for semgrep patterns in C#

### DIFF
--- a/src/prep.common
+++ b/src/prep.common
@@ -26,8 +26,12 @@ mkdir -p test/corpus
 (
   cd test/corpus
   rm -f inherited
-  corpus=../../../tree-sitter-"$name"/test/corpus
-  if [[ -e "$corpus" ]]; then
-    ln -sf "$corpus" inherited
-  fi
+  # The root of the tests is either 'test/corpus' or 'corpus' as per
+  # tree-sitter documentation.
+  for dir in test/corpus corpus; do
+    corpus=../../../tree-sitter-"$name"/$dir
+    if [[ -e "$corpus" ]]; then
+      ln -sf "$corpus" inherited
+    fi
+  done
 )

--- a/src/semgrep-c-sharp/test/corpus/semgrep.txt
+++ b/src/semgrep-c-sharp/test/corpus/semgrep.txt
@@ -1,0 +1,156 @@
+=====================================
+Metavariables
+=====================================
+
+class $CLASS {
+  void $FUNC($TYPE $PARAM) {
+    $COND ? $V1 : $V2;
+  }
+}
+
+---
+
+(compilation_unit
+  (class_declaration
+    (identifier)
+    (declaration_list
+      (method_declaration
+        (void_keyword)
+        (identifier)
+        (parameter_list (parameter (identifier) (identifier)))
+        (block
+          (expression_statement
+            (conditional_expression (identifier) (identifier) (identifier))
+          )
+        )
+      )
+    )
+  )
+)
+
+=====================================
+Ellipsis for expression
+=====================================
+
+class Foo {
+  void Bar() {
+    a = 0;
+    ...;
+    b = 0;
+  }
+}
+
+---
+
+(compilation_unit
+  (class_declaration
+    (identifier)
+    (declaration_list
+      (method_declaration
+        (void_keyword)
+        (identifier)
+        (parameter_list)
+        (block
+          (expression_statement
+            (assignment_expression
+              (identifier) (assignment_operator) (integer_literal))
+          )
+          (expression_statement (ellipsis))
+          (expression_statement
+            (assignment_expression
+              (identifier) (assignment_operator) (integer_literal)
+            )
+          )
+        )
+      )
+    )
+  )
+)
+
+=====================================
+Ellipsis for statements
+=====================================
+
+class Foo {
+  void Bar() {
+    a = 0;
+    ...
+    b = 0;
+  }
+}
+
+---
+
+(compilation_unit
+  (class_declaration
+    (identifier)
+    (declaration_list
+      (method_declaration
+        (void_keyword)
+        (identifier)
+        (parameter_list)
+        (block
+          (expression_statement
+            (assignment_expression
+              (identifier)
+              (assignment_operator)
+              (integer_literal)
+            )
+          )
+          (ellipsis)
+          (expression_statement
+            (assignment_expression
+              (identifier)
+              (assignment_operator)
+              (integer_literal)
+            )
+          )
+        )
+      )
+    )
+  )
+)
+
+=====================================
+Deep expression ellipsis
+=====================================
+
+class Foo {
+  void Bar() {
+    a = <... 0 ...>;
+  }
+}
+
+---
+
+(compilation_unit
+  (class_declaration
+    (identifier)
+    (declaration_list
+      (method_declaration
+        (void_keyword)
+        (identifier)
+        (parameter_list)
+        (block
+          (expression_statement
+            (assignment_expression
+              (identifier)
+              (assignment_operator)
+              (deep_ellipsis (integer_literal))
+            )
+          )
+        )
+      )
+    )
+  )
+)
+
+=====================================
+Toplevel expression
+=====================================
+
+42
+
+---
+
+(compilation_unit (integer_literal))

--- a/src/semgrep-c-sharp/test/corpus/semgrep.txt
+++ b/src/semgrep-c-sharp/test/corpus/semgrep.txt
@@ -97,7 +97,7 @@ class Foo {
               (integer_literal)
             )
           )
-          (ellipsis)
+          (expression_statement (ellipsis))
           (expression_statement
             (assignment_expression
               (identifier)
@@ -149,8 +149,27 @@ class Foo {
 Toplevel expression
 =====================================
 
+__SEMGREP_EXPRESSION
 42
 
 ---
 
-(compilation_unit (integer_literal))
+(compilation_unit (semgrep_expression (integer_literal)))
+
+=====================================
+Argument ellipsis
+=====================================
+
+__SEMGREP_EXPRESSION
+foo(...)
+
+---
+
+(compilation_unit
+  (semgrep_expression
+    (invocation_expression
+      (identifier)
+      (argument_list (argument (ellipsis)))
+    )
+  )
+)


### PR DESCRIPTION
I added support for the following and the tests pass:
- metavariables,
- expression ellipsis,
- deep expression ellipsis,
- statement ellipsis

What doesn't work for now is toplevel expressions. I'm getting a parse error on a test case which should parsed as a statement but is parsed as an expression.
