### PR TITLE
Extend semgrep-rust with semgrep syntax

### DIFF
--- a/src/semgrep-rust/grammar.js
+++ b/src/semgrep-rust/grammar.js
@@ -1,15 +1,60 @@
 /*
  * semgrep-rust
  *
- * Extend the standard rust grammar with metavariable pattern constructs.
- * There is no need to extend it for ellipsis because ellipsis are already
- * part of the Rust language.
+ * Extend the original tree-sitter Rust grammar with semgrep-specific constructs
+ * used to represent semgrep patterns.
  */
 
 const standard_grammar = require('tree-sitter-rust/grammar');
 
 module.exports = grammar(standard_grammar, {
-    name: 'rust',
+  name: 'rust',
 
-    rules: {}
+  rules: {
+
+    // Entry point
+    source_file: ($, previous) => {
+      return choice(
+        previous,
+        $.semgrep_expression
+      );
+    },
+
+    // Alternate "entry point". Allows parsing a standalone expression.
+    semgrep_expression: $ => seq('__SEMGREP_EXPRESSION', $._expression),
+
+    // Metavariables
+    identifier: ($, previous) => {
+      return token(
+        choice(
+          previous,
+          /\$[A-Z_][A-Z_0-9]*/
+        )
+      );
+    },
+
+    // Statement ellipsis: '...' not followed by ';'
+    _expression_statement: ($, previous) => {
+      return choice(
+        previous,
+        prec.right(100, seq($.ellipsis, ';')),  // expression ellipsis
+        prec.right(100, $.ellipsis),  // statement ellipsis
+      );
+    },
+
+    // Expression ellipsis
+    _expression: ($, previous) => {
+      return choice(
+        ...previous.members,
+        $.ellipsis,
+        $.deep_ellipsis
+      );
+    },
+
+    deep_ellipsis: $ => seq(
+      '<...', $._expression, '...>'
+    ),
+
+    ellipsis: $ => '...',
+  }
 });

--- a/src/semgrep-rust/test/corpus/semgrep.txt
+++ b/src/semgrep-rust/test/corpus/semgrep.txt
@@ -1,0 +1,191 @@
+=====================================
+Metavariables
+=====================================
+
+impl $CLASS {
+  pub fn $FUNC($PARAM: $TYPE) -> $RETTYPE {
+    if $COND {
+        $V1
+    } else {
+        $V2
+    }
+  }
+}
+
+---
+
+(source_file
+  (item
+    (impl_item
+      (type_identifier)
+      (impl_block
+        (impl_block_item
+          (visibility_modifier)
+          (function_item
+            (function_declaration
+              (identifier)
+              (parameters
+                (parameter
+                  (identifier)
+                  (type_identifier)))
+              (type_identifier))
+            (block
+              (if_expression
+                (identifier) (block (identifier))
+                (else_clause (block (identifier)))
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+
+=====================================
+Ellipsis for expression
+=====================================
+
+impl Foo {
+  fn bar() {
+    let a = 0;
+    ...;
+    let b = 0;
+  }
+}
+
+---
+
+(source_file
+  (item
+    (impl_item
+      (type_identifier)
+      (impl_block
+        (impl_block_item
+          (function_item
+            (function_declaration
+              (identifier)
+              (parameters))
+            (block
+              (let_declaration
+                (identifier)
+                (integer_literal))
+              (ellipsis)
+              (let_declaration
+                (identifier)
+                (integer_literal)
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+
+=====================================
+Ellipsis for statements
+=====================================
+
+impl Foo {
+  fn bar() {
+    let a = 0;
+    ...
+    let b = 0;
+  }
+}
+
+---
+
+(source_file
+  (item
+    (impl_item
+      (type_identifier)
+      (impl_block
+        (impl_block_item
+          (function_item
+            (function_declaration
+              (identifier)
+              (parameters))
+            (block
+              (let_declaration
+                (identifier)
+                (integer_literal))
+              (ellipsis)
+              (let_declaration
+                (identifier)
+                (integer_literal)
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+
+=====================================
+Deep expression ellipsis
+=====================================
+
+impl Foo {
+  fn bar() {
+    let a = <... 0 ...>;
+  }
+}
+
+---
+
+(source_file
+  (item
+    (impl_item
+      (type_identifier)
+      (impl_block
+        (impl_block_item
+          (function_item
+            (function_declaration
+              (identifier)
+              (parameters))
+            (block
+              (let_declaration
+                (identifier)
+                (deep_ellipsis
+                  (integer_literal)
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+
+=====================================
+Toplevel expression
+=====================================
+
+__SEMGREP_EXPRESSION
+42
+
+---
+
+(source_file (semgrep_expression (integer_literal)))
+
+=====================================
+Argument ellipsis
+=====================================
+
+__SEMGREP_EXPRESSION
+foo(...)
+
+---
+
+(source_file
+  (semgrep_expression
+    (call_expression
+      (identifier)
+      (arguments (ellipsis))
+      )
+    )
+  )


### PR DESCRIPTION
We have to be careful because `$X` is a valid construct within Rust macros. The testcases I added seem to work fine though.