### PR TITLE
extend kotlin grammar with metavariable syntax

### DIFF
--- a/src/semgrep-kotlin/grammar.js
+++ b/src/semgrep-kotlin/grammar.js
@@ -1,7 +1,8 @@
 /*
  * semgrep-kotlin
  *
- * TODO: Extend the standard kotlin grammar with ellipsis and metavariable pattern constructs
+ * Extend the standard kotlin grammar with metavariable pattern constructs.
+ * Ellipsis are in the kotlin grammar, so no need to extend for ellipsis.
  */
 
 const standard_grammar = require('tree-sitter-kotlin/grammar');
@@ -10,6 +11,6 @@ module.exports = grammar(standard_grammar, {
     name: 'kotlin',
 
     rules: {
-
+        identifier: $ => /\$?[a-zA-Z_][a-zA-Z_0-9]*/
     }
 });

--- a/src/semgrep-kotlin/grammar.js
+++ b/src/semgrep-kotlin/grammar.js
@@ -11,6 +11,34 @@ module.exports = grammar(standard_grammar, {
     name: 'kotlin',
 
     rules: {
-        identifier: $ => /\$?[a-zA-Z_][a-zA-Z_0-9]*/
+
+        // Entry point
+        source_file: ($, previous) => {
+          return choice(
+            previous,
+            $.semgrep_expression
+          );
+        },
+    
+        // Alternate "entry point". Allows parsing a standalone expression.
+        semgrep_expression: $ => seq('__SEMGREP_EXPRESSION', $._expression),
+
+        // Metavariables
+        simple_identifier: ($, previous) => {
+            return choice(
+                previous,
+                /\$[a-zA-Z_][a-zA-Z_0-9]*/
+            )
+        },
+        
+        // Statement ellipsis: '...' not followed by ';'
+        _expression: ($, previous) => {
+            return choice(
+                previous,
+                $.ellipsis,  // statement ellipsis
+            );
+        },
+
+        ellipsis: $ => '...',
     }
 });

--- a/src/semgrep-kotlin/test/corpus/semgrep.txt
+++ b/src/semgrep-kotlin/test/corpus/semgrep.txt
@@ -1,0 +1,55 @@
+=====================================
+Metavariables
+=====================================
+
+class $CLASS {
+    fun $FOO($VAR:$TYPE) {
+        foo($X, 2)
+    }
+}
+
+---
+
+(source_file
+  (class_declaration
+    (type_identifier)
+    (class_body
+      (function_declaration
+        (simple_identifier)
+        (parameter
+          (simple_identifier)
+          (user_type
+            (type_identifier)))
+        (function_body
+          (statements
+            (call_expression
+              (simple_identifier)
+              (call_suffix
+                (value_arguments
+                  (value_argument
+                    (simple_identifier))
+                  (value_argument
+                    (integer_literal)))))))))))
+
+
+=====================================
+Ellipsis
+=====================================
+
+class Foo {
+  fun bar() {
+    ...
+  }
+}
+
+---
+
+(source_file
+  (class_declaration
+    (type_identifier)
+    (class_body
+      (function_declaration
+        (simple_identifier)
+        (function_body
+          (statements
+            (ellipsis)))))))


### PR DESCRIPTION
Test plan:

Run 
```make test``` in the lang/kotlin folder. Check that all written tests pass.