### PR TITLE
Return token in identifier in C#

### DIFF
--- a/src/semgrep-c-sharp/grammar.js
+++ b/src/semgrep-c-sharp/grammar.js
@@ -38,11 +38,9 @@ module.exports = grammar(standard_grammar, {
 
     // Metavariables
     identifier: ($, previous) => {
-      return token(
-        choice(
-          previous,
-          /\$[A-Z_][A-Z_0-9]*/
-        )
+      return choice(
+        previous,
+        token(/\$[A-Z_][A-Z_0-9]*/)
       );
     },
 


### PR DESCRIPTION
Upstream parser already returns a token, so we don't want to call token again on the previous.

Fixes error message:
```
Error processing rule identifier
Details:
  Grammar error: Unexpected rule Symbol(Symbol { kind: NonTerminal, index: 207 })
```

I have tested this using `make test`, but not integration-tested it with semgrep.